### PR TITLE
Move SkipIfNotInVM to guest package

### DIFF
--- a/guest/skip.go
+++ b/guest/skip.go
@@ -1,0 +1,22 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package guest has functions for use in tests running in VM guests.
+package guest
+
+import (
+	"testing"
+
+	"github.com/u-root/u-root/pkg/cmdline"
+)
+
+// SkipIfNotInVM skips the test if it is not running in a vmtest-started VM.
+//
+// The presence of "uroot.vmtest" on the kernel commandline is used to
+// determine this.
+func SkipIfNotInVM(t testing.TB) {
+	if !cmdline.ContainsFlag("uroot.vmtest") {
+		t.Skip("Skipping test -- must be run inside vmtest VM")
+	}
+}

--- a/tests/gobench/bench_test.go
+++ b/tests/gobench/bench_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hugelgupf/vmtest"
+	"github.com/hugelgupf/vmtest/guest"
 )
 
 func TestRunBenchmarkInVM(t *testing.T) {
@@ -18,7 +19,7 @@ func fib(n int) int {
 }
 
 func BenchmarkFib10(b *testing.B) {
-	vmtest.SkipIfNotInVM(b)
+	guest.SkipIfNotInVM(b)
 
 	for n := 0; n < b.N; n++ {
 		fib(10)

--- a/tests/gohello/helloworld_test.go
+++ b/tests/gohello/helloworld_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hugelgupf/vmtest"
+	"github.com/hugelgupf/vmtest/guest"
 )
 
 func TestStartVM(t *testing.T) {
@@ -11,7 +12,7 @@ func TestStartVM(t *testing.T) {
 }
 
 func TestHelloWorld(t *testing.T) {
-	vmtest.SkipIfNotInVM(t)
+	guest.SkipIfNotInVM(t)
 
 	t.Logf("Hello world")
 }

--- a/vmtest.go
+++ b/vmtest.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/hugelgupf/vmtest/qemu"
-	"github.com/u-root/u-root/pkg/cmdline"
 	"github.com/u-root/u-root/pkg/cp"
 )
 
@@ -137,15 +136,5 @@ func StartVM(t testing.TB, o *VMOptions) *qemu.VM {
 func SkipWithoutQEMU(t testing.TB) {
 	if _, ok := os.LookupEnv("VMTEST_QEMU"); !ok {
 		t.Skip("QEMU vmtest is skipped unless VMTEST_QEMU is set")
-	}
-}
-
-// SkipIfNotInVM skips the test if it is not running in a vmtest-started VM.
-//
-// The presence of "uroot.vmtest" on the kernel commandline is used to
-// determine this.
-func SkipIfNotInVM(t testing.TB) {
-	if !cmdline.ContainsFlag("uroot.vmtest") {
-		t.Skip("Skipping test -- must be run inside vmtest VM")
 	}
 }


### PR DESCRIPTION
Clearly start delineating API to used by host to start VM and API used by tests in guest.