### PR TITLE
Use env var to determine in-guest presence

### DIFF
--- a/guest/skip.go
+++ b/guest/skip.go
@@ -6,17 +6,16 @@
 package guest
 
 import (
+	"os"
 	"testing"
-
-	"github.com/u-root/u-root/pkg/cmdline"
 )
 
 // SkipIfNotInVM skips the test if it is not running in a vmtest-started VM.
 //
-// The presence of "uroot.vmtest" on the kernel commandline is used to
-// determine this.
+// The presence of VMTEST_IN_GUEST=1 env var (which can be passed on the
+// kernel commandline) is used to determine this.
 func SkipIfNotInVM(t testing.TB) {
-	if !cmdline.ContainsFlag("uroot.vmtest") {
+	if os.Getenv("VMTEST_IN_GUEST") != "1" {
 		t.Skip("Skipping test -- must be run inside vmtest VM")
 	}
 }

--- a/vmtest.go
+++ b/vmtest.go
@@ -196,9 +196,11 @@ func startVM(t testing.TB, o *VMOptions) *qemu.VM {
 
 	qopts := []qemu.Fn{
 		qemu.LogSerialByLine(qemu.PrintLineWithPrefix(o.ConsoleOutputPrefix, t.Logf)),
-		// Tests use this cmdline arg to identify they are running inside a
-		// vmtest using SkipIfNotInVM
-		qemu.WithAppendKernel("uroot.vmtest"),
+		// Tests use this env var to identify they are running inside a
+		// vmtest using SkipIfNotInVM.
+		//
+		// Older tests use the presence of uroot.vmtest in the kernel command-line.
+		qemu.WithAppendKernel("VMTEST_IN_GUEST=1", "uroot.vmtest"),
 		qemu.VirtioRandom(),
 	}
 	if o.SharedDir != "" {


### PR DESCRIPTION
Use VMTEST_IN_GUEST=1 rather than uroot.vmtest presence on the kernel command-line.