### PR TITLE
qemu: implement support for OVMF files

### DIFF
--- a/qemu/qfirmware/qfirmware.go
+++ b/qemu/qfirmware/qfirmware.go
@@ -1,0 +1,46 @@
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package qfirmware provides firmware configurators for use with the Go qemu
+// API.
+package qfirmware
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hugelgupf/vmtest/qemu"
+)
+
+// WithDefaultOVMF sets the QEMU arguments for enabling UEFI with OVMF firmware.
+//
+// OVMF requires the VM to be run with atleast 1 GB of memory and an machine type with smm turned on.
+//
+//	qemu.ArbitraryArgs("-m", "2G", "-machine", "type=q35,smm=on")
+func WithDefaultOVMF() qemu.Fn {
+	return WithOVMF("", "")
+}
+
+// WithOVMF sets the QEMU arguments for enabling UEFI with OVMF firmware.
+//
+// ovmfCode and ovmfVars are substituted by VMTEST_OVMF_CODE and VMTEST_OVMF_VARS if empty.
+//
+// OVMF requires the VM to be run with atleast 1 GB of memory and an machine type with msm turned on.
+//
+//	qemu.ArbitraryArgs("-m", "2G", "-machine", "type=q35,smm=on")
+func WithOVMF(ovmfCode, ovmfVars string) qemu.Fn {
+	if ovmfCode == "" {
+		ovmfCode = os.Getenv("VMTEST_OVMF_CODE")
+	}
+	if ovmfVars == "" {
+		ovmfVars = os.Getenv("VMTEST_OVMF_VARS")
+	}
+	return func(alloc *qemu.IDAllocator, opts *qemu.Options) error {
+		opts.AppendQEMU(
+			"-drive", fmt.Sprintf("if=pflash,format=raw,unit=0,file=%s,readonly=on", ovmfCode),
+			"-drive", fmt.Sprintf("if=pflash,format=raw,unit=1,file=%s", ovmfVars),
+		)
+		return nil
+	}
+}


### PR DESCRIPTION
I haven't really tested this.  This is just me stubbing out what is needed for this framework to support OVMF files declaratively instead of passing them as Qemu args. This is mostly to gather feedback on how this support should look like.


Based off on my POC test for `go-uefi` here.

```go
func TestStartVM(t *testing.T) {
	ovmf := "-drive if=pflash,format=raw,unit=0,file=ovmf/OVMF_CODE.secboot.fd,readonly=on -drive if=pflash,format=raw,unit=1,file=ovmf/OVMF_VARS.fd"

	initramfs := uroot.Opts{
		TempDir:   t.TempDir(),
		InitCmd:   "init",
		UinitCmd:  "ls",
		UinitArgs: []string{"/sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"},
		Commands: uroot.BusyBoxCmds(
			"github.com/u-root/u-root/cmds/core/init",
			"github.com/u-root/u-root/cmds/core/cat",
			"github.com/u-root/u-root/cmds/core/ls",
		),
	}
	vm, err := qemu.Start(
		qemu.ArchAMD64,
		qemu.WithQEMUCommand(fmt.Sprintf("qemu-system-x86_64 -enable-kvm -m 1G -machine type=q35,smm=on %s", ovmf)),
		qemu.WithKernel("/boot/vmlinuz-linux"),
		uqemu.WithUrootInitramfsT(t, initramfs),
		qemu.WithAppendKernel("console=ttyS0 earlyprintk=ttyS0"),
		qemu.LogSerialByLine(qemu.PrintLineWithPrefix("vm", t.Logf)),
	)
	if err != nil {
		t.Fatalf("Failed to start VM: %v", err)
	}
	t.Logf("cmdline: %#v", vm.CmdlineQuoted())

	if _, err := vm.Console.ExpectString("SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"); err != nil {
		t.Errorf("Error expecting kernel command line string: %v", err)
	}

	vm.Kill()
}
```