### PR TITLE
Share VMTEST_GOCOVERDIR with VM instead of GOCOVERDIR

### DIFF
--- a/coverage.go
+++ b/coverage.go
@@ -14,13 +14,13 @@ import (
 	"github.com/hugelgupf/vmtest/testtmp"
 )
 
-// ShareGOCOVERDIR shares GOCOVERDIR with the guest if it's available in the
+// ShareGOCOVERDIR shares VMTEST_GOCOVERDIR with the guest if it's available in the
 // environment.
 //
 // Call guest.GOCOVERDIR to set up the directory in the guest.
 func ShareGOCOVERDIR() Opt {
 	return func(t testing.TB, v *VMOptions) error {
-		goCov := os.Getenv("GOCOVERDIR")
+		goCov := os.Getenv("VMTEST_GOCOVERDIR")
 		if goCov == "" {
 			return nil
 		}

--- a/tests/gocover/helloworld_test.go
+++ b/tests/gocover/helloworld_test.go
@@ -26,10 +26,10 @@ func TestStartVM(t *testing.T) {
 		t.Setenv("VMTEST_GO_PROFILE", goProfile)
 	}
 
-	goCov := os.Getenv("GOCOVERDIR")
+	goCov := os.Getenv("VMTEST_GOCOVERDIR")
 	if goCov == "" {
 		goCov = testtmp.TempDir(t)
-		t.Setenv("GOCOVERDIR", goCov)
+		t.Setenv("VMTEST_GOCOVERDIR", goCov)
 	}
 
 	t.Run("test", func(t *testing.T) {

--- a/tests/shellgocoverdir/helloworld_test.go
+++ b/tests/shellgocoverdir/helloworld_test.go
@@ -21,10 +21,10 @@ func TestStartVM(t *testing.T) {
 		"donothing\nsync\necho \"TESTS PASSED MARKER\"\nshutdown",
 	} {
 		t.Run(script, func(t *testing.T) {
-			goCov := os.Getenv("GOCOVERDIR")
+			goCov := os.Getenv("VMTEST_GOCOVERDIR")
 			if goCov == "" {
 				goCov = testtmp.TempDir(t)
-				t.Setenv("GOCOVERDIR", goCov)
+				t.Setenv("VMTEST_GOCOVERDIR", goCov)
 			}
 
 			vmtest.RunCmdsInVM(t, script,


### PR DESCRIPTION
When running VM tests with `GOCOVERDIR=$x go test -cover`, Go overrides the GOCOVERDIR for the test process, but does not share the coverage data in any way.

Upstream issue is https://github.com/golang/go/issues/60182