### PR TITLE
Coverage of vminit only when running in vmtest

### DIFF
--- a/govmtest/gotest.go
+++ b/govmtest/gotest.go
@@ -201,9 +201,6 @@ func Run(t testing.TB, name string, mods ...Modifier) {
 			"github.com/u-root/u-root/cmds/core/init",
 			"github.com/hugelgupf/vmtest/vminit/shutdownafter",
 			"github.com/hugelgupf/vmtest/vminit/vmmount",
-		),
-		// Collect coverage of gouinit.
-		uimage.WithCoveredCommands(
 			"github.com/hugelgupf/vmtest/vminit/gouinit",
 		),
 		uimage.WithBinaryCommands("cmd/test2json"),

--- a/internal/cover/qemu.go
+++ b/internal/cover/qemu.go
@@ -1,0 +1,29 @@
+// Copyright 2023 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package cover adds an internal coverage function.
+package cover
+
+import (
+	"slices"
+
+	"github.com/u-root/mkuimage/uimage"
+)
+
+// WithCoverInstead removes a command already added to options and instead adds
+// it back with WithCoveredCommands.
+//
+// This allows a cmd to be built as part of busybox for regular vmtest users,
+// but with coverage for vmtest's own tests.
+func WithCoverInstead(cmd string) uimage.Modifier {
+	return func(o *uimage.Opts) error {
+		for i := range o.Commands {
+			o.Commands[i].Packages = slices.DeleteFunc(o.Commands[i].Packages, func(s string) bool {
+				return s == cmd
+			})
+		}
+
+		return o.Apply(uimage.WithCoveredCommands(cmd))
+	}
+}

--- a/scriptvm/shelltest.go
+++ b/scriptvm/shelltest.go
@@ -95,9 +95,6 @@ func Start(t testing.TB, name, script string, mods ...Modifier) *qemu.VM {
 			"github.com/u-root/u-root/cmds/core/gosh",
 			"github.com/hugelgupf/vmtest/vminit/shutdownafter",
 			"github.com/hugelgupf/vmtest/vminit/vmmount",
-		),
-		// Collect coverage of shelluinit.
-		uimage.WithCoveredCommands(
 			"github.com/hugelgupf/vmtest/vminit/shelluinit",
 		),
 		uimage.WithInit("init"),

--- a/tests/gobench/bench_test.go
+++ b/tests/gobench/bench_test.go
@@ -5,10 +5,14 @@ import (
 
 	"github.com/hugelgupf/vmtest/govmtest"
 	"github.com/hugelgupf/vmtest/guest"
+	"github.com/hugelgupf/vmtest/internal/cover"
 )
 
 func TestRunBenchmarkInVM(t *testing.T) {
-	govmtest.Run(t, "vm", govmtest.WithPackageToTest("github.com/hugelgupf/vmtest/tests/gobench"))
+	govmtest.Run(t, "vm",
+		govmtest.WithPackageToTest("github.com/hugelgupf/vmtest/tests/gobench"),
+		govmtest.WithUimage(cover.WithCoverInstead("github.com/hugelgupf/vmtest/vminit/gouinit")),
+	)
 }
 
 func fib(n int) int {

--- a/tests/gocover/helloworld_test.go
+++ b/tests/gocover/helloworld_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hugelgupf/vmtest/govmtest"
 	"github.com/hugelgupf/vmtest/guest"
+	"github.com/hugelgupf/vmtest/internal/cover"
 	"github.com/hugelgupf/vmtest/qemu"
 	"github.com/hugelgupf/vmtest/testtmp"
 	"github.com/u-root/gobusybox/src/pkg/golang"
@@ -33,7 +34,10 @@ func TestStartVM(t *testing.T) {
 	}
 
 	t.Run("test", func(t *testing.T) {
-		govmtest.Run(t, "vm", govmtest.WithPackageToTest("github.com/hugelgupf/vmtest/tests/gocover"))
+		govmtest.Run(t, "vm",
+			govmtest.WithPackageToTest("github.com/hugelgupf/vmtest/tests/gocover"),
+			govmtest.WithUimage(cover.WithCoverInstead("github.com/hugelgupf/vmtest/vminit/gouinit")),
+		)
 	})
 
 	// Check VMTEST_GO_PROFILE coverage collected.

--- a/tests/gofail/fail_test.go
+++ b/tests/gofail/fail_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hugelgupf/vmtest/govmtest"
+	"github.com/hugelgupf/vmtest/internal/cover"
 	"github.com/hugelgupf/vmtest/internal/failtesting"
 	"github.com/hugelgupf/vmtest/qemu"
 )
@@ -13,7 +14,10 @@ func TestStartVM(t *testing.T) {
 	qemu.SkipWithoutQEMU(t)
 
 	ft := &failtesting.TB{TB: t}
-	govmtest.Run(ft, "vm", govmtest.WithPackageToTest("github.com/hugelgupf/vmtest/tests/gofail"))
+	govmtest.Run(ft, "vm",
+		govmtest.WithPackageToTest("github.com/hugelgupf/vmtest/tests/gofail"),
+		govmtest.WithUimage(cover.WithCoverInstead("github.com/hugelgupf/vmtest/vminit/gouinit")),
+	)
 
 	if !ft.HasFailed {
 		t.Error("Go VM test did not fail as expected.")

--- a/tests/gohello/helloworld_test.go
+++ b/tests/gohello/helloworld_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hugelgupf/vmtest/govmtest"
 	"github.com/hugelgupf/vmtest/guest"
+	"github.com/hugelgupf/vmtest/internal/cover"
 	"github.com/hugelgupf/vmtest/qemu"
 	"github.com/u-root/mkuimage/uimage"
 )
@@ -15,6 +16,7 @@ func TestStartVM(t *testing.T) {
 	govmtest.Run(t, "vm",
 		govmtest.WithPackageToTest("github.com/hugelgupf/vmtest/tests/gohello"),
 		govmtest.WithUimage(
+			cover.WithCoverInstead("github.com/hugelgupf/vmtest/vminit/gouinit"),
 			uimage.WithBusyboxCommands(
 				"github.com/u-root/u-root/cmds/core/dhclient",
 				"github.com/u-root/u-root/cmds/core/ls",

--- a/tests/gokcov/helloworld_test.go
+++ b/tests/gokcov/helloworld_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hugelgupf/vmtest/govmtest"
 	"github.com/hugelgupf/vmtest/guest"
+	"github.com/hugelgupf/vmtest/internal/cover"
 	"github.com/hugelgupf/vmtest/qemu"
 	"github.com/hugelgupf/vmtest/testtmp"
 )
@@ -25,7 +26,10 @@ func TestStartVM(t *testing.T) {
 	// Kernel coverage is copied to kcovDir during t.Cleanup, so induce it
 	// before the test is over by using a sub-test.
 	t.Run("test", func(t *testing.T) {
-		govmtest.Run(t, "vm", govmtest.WithPackageToTest("github.com/hugelgupf/vmtest/tests/gokcov"))
+		govmtest.Run(t, "vm",
+			govmtest.WithPackageToTest("github.com/hugelgupf/vmtest/tests/gokcov"),
+			govmtest.WithUimage(cover.WithCoverInstead("github.com/hugelgupf/vmtest/vminit/gouinit")),
+		)
 	})
 
 	if _, err := os.Stat(filepath.Join(kcovDir, "TestStartVM", "test", "0", "kernel_coverage.tar")); err != nil {

--- a/tests/gotimeout/helloworld_test.go
+++ b/tests/gotimeout/helloworld_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/hugelgupf/vmtest/govmtest"
+	"github.com/hugelgupf/vmtest/internal/cover"
 	"github.com/hugelgupf/vmtest/internal/failtesting"
 	"github.com/hugelgupf/vmtest/qemu"
 )
@@ -17,6 +18,7 @@ func TestStartVM(t *testing.T) {
 	govmtest.Run(ft, "vm",
 		govmtest.WithPackageToTest("github.com/hugelgupf/vmtest/tests/gotimeout"),
 		govmtest.WithGoTestTimeout(2*time.Second),
+		govmtest.WithUimage(cover.WithCoverInstead("github.com/hugelgupf/vmtest/vminit/gouinit")),
 	)
 
 	if !ft.HasFailed {

--- a/tests/shellfail/helloworld_test.go
+++ b/tests/shellfail/helloworld_test.go
@@ -3,6 +3,7 @@ package helloworld
 import (
 	"testing"
 
+	"github.com/hugelgupf/vmtest/internal/cover"
 	"github.com/hugelgupf/vmtest/internal/failtesting"
 	"github.com/hugelgupf/vmtest/qemu"
 	"github.com/hugelgupf/vmtest/scriptvm"
@@ -15,6 +16,7 @@ func TestStartVM(t *testing.T) {
 	ft := &failtesting.TB{TB: t}
 	scriptvm.Run(ft, "vm", "false", scriptvm.WithUimage(
 		uimage.WithBusyboxCommands("github.com/u-root/u-root/cmds/core/false"),
+		cover.WithCoverInstead("github.com/hugelgupf/vmtest/vminit/shelluinit"),
 	))
 
 	if !ft.HasFailed {

--- a/tests/shellgocoverdir/helloworld_test.go
+++ b/tests/shellgocoverdir/helloworld_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hugelgupf/vmtest/internal/cover"
 	"github.com/hugelgupf/vmtest/qemu"
 	"github.com/hugelgupf/vmtest/scriptvm"
 	"github.com/hugelgupf/vmtest/testtmp"
@@ -30,6 +31,7 @@ func TestStartVM(t *testing.T) {
 
 			scriptvm.Run(t, "vm", script,
 				scriptvm.WithUimage(
+					cover.WithCoverInstead("github.com/hugelgupf/vmtest/vminit/shelluinit"),
 					uimage.WithCoveredCommands(
 						"github.com/hugelgupf/vmtest/tests/cmds/donothing",
 					),

--- a/tests/shellhello/helloworld_test.go
+++ b/tests/shellhello/helloworld_test.go
@@ -3,6 +3,7 @@ package helloworld
 import (
 	"testing"
 
+	"github.com/hugelgupf/vmtest/internal/cover"
 	"github.com/hugelgupf/vmtest/qemu"
 	"github.com/hugelgupf/vmtest/scriptvm"
 )
@@ -10,5 +11,7 @@ import (
 func TestStartVM(t *testing.T) {
 	qemu.SkipWithoutQEMU(t)
 
-	scriptvm.Run(t, "vm", `echo "Hello World"`)
+	scriptvm.Run(t, "vm", `echo "Hello World"`,
+		scriptvm.WithUimage(cover.WithCoverInstead("github.com/hugelgupf/vmtest/vminit/shelluinit")),
+	)
 }

--- a/tests/shellkcov/helloworld_test.go
+++ b/tests/shellkcov/helloworld_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hugelgupf/vmtest/internal/cover"
 	"github.com/hugelgupf/vmtest/qemu"
 	"github.com/hugelgupf/vmtest/scriptvm"
 	"github.com/hugelgupf/vmtest/testtmp"
@@ -24,7 +25,9 @@ func TestStartVM(t *testing.T) {
 	// Kernel coverage is copied to kcovDir during t.Cleanup, so induce it
 	// before the test is over by using a sub-test.
 	t.Run("test", func(t *testing.T) {
-		scriptvm.Run(t, "vm", `echo "Hello World"`)
+		scriptvm.Run(t, "vm", `echo "Hello World"`,
+			scriptvm.WithUimage(cover.WithCoverInstead("github.com/hugelgupf/vmtest/vminit/shelluinit")),
+		)
 	})
 
 	if _, err := os.Stat(filepath.Join(kcovDir, "TestStartVM", "test", "0", "kernel_coverage.tar")); err != nil {


### PR DESCRIPTION
Users don't need coverage collection of vminit.